### PR TITLE
[codex] Implement Bybit spot WebSocket subscriptions

### DIFF
--- a/src/exchanges/bybit/codec.rs
+++ b/src/exchanges/bybit/codec.rs
@@ -1,7 +1,8 @@
 use crate::core::errors::ExchangeError;
 use crate::core::kernel::WsCodec;
 use crate::exchanges::bybit::types::{
-    BybitWebSocketKline, BybitWebSocketOrderBook, BybitWebSocketTicker, BybitWebSocketTrade,
+    BybitKlineData, BybitWebSocketKline, BybitWebSocketOrderBook, BybitWebSocketTicker,
+    BybitWebSocketTrade,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
@@ -115,17 +116,28 @@ impl WsCodec for BybitCodec {
                                     }
                                 }
                                 t if t.starts_with("publicTrade.") => {
-                                    if let Ok(trade) =
-                                        serde_json::from_value::<BybitWebSocketTrade>(data.clone())
-                                    {
+                                    let trade_data = data
+                                        .as_array()
+                                        .and_then(|items| items.first())
+                                        .unwrap_or(data);
+                                    if let Ok(trade) = serde_json::from_value::<BybitWebSocketTrade>(
+                                        trade_data.clone(),
+                                    ) {
                                         return Ok(Some(BybitWsEvent::Trade { data: trade }));
                                     }
                                 }
                                 t if t.starts_with("kline.") => {
+                                    let kline_data = data
+                                        .as_array()
+                                        .and_then(|items| items.first())
+                                        .unwrap_or(data);
                                     if let Ok(kline) =
-                                        serde_json::from_value::<BybitWebSocketKline>(data.clone())
+                                        serde_json::from_value::<BybitKlineData>(kline_data.clone())
                                     {
-                                        return Ok(Some(BybitWsEvent::Kline { data: kline }));
+                                        let symbol = t.rsplit('.').next().unwrap_or("").to_string();
+                                        return Ok(Some(BybitWsEvent::Kline {
+                                            data: BybitWebSocketKline { symbol, kline },
+                                        }));
                                     }
                                 }
                                 _ => {}
@@ -145,6 +157,31 @@ impl WsCodec for BybitCodec {
                 // Ignore other message types (ping, pong, close)
                 Ok(None)
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::kernel::WsCodec;
+    use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn decodes_bybit_ticker_message() {
+        let message = Message::Text(
+            r#"{"topic":"tickers.BTCUSDT","type":"snapshot","ts":1710000000000,"data":{"symbol":"BTCUSDT","lastPrice":"43000","price24hPcnt":"0.01","highPrice24h":"44000","lowPrice24h":"42000","volume24h":"100","turnover24h":"4300000"}}"#
+                .to_string(),
+        );
+
+        let decoded = BybitCodec.decode_message(message).unwrap();
+
+        match decoded {
+            Some(BybitWsEvent::Ticker { data }) => {
+                assert_eq!(data.symbol, "BTCUSDT");
+                assert_eq!(data.price, "43000");
+            }
+            other => panic!("expected ticker event, got {other:?}"),
         }
     }
 }

--- a/src/exchanges/bybit/connector/market_data.rs
+++ b/src/exchanges/bybit/connector/market_data.rs
@@ -1,9 +1,11 @@
 use crate::core::errors::ExchangeError;
-use crate::core::kernel::RestClient;
+use crate::core::kernel::{ws::WsSession, RestClient};
 use crate::core::traits::MarketDataSource;
 use crate::core::types::{
-    Kline, KlineInterval, Market, MarketDataType, SubscriptionType, WebSocketConfig,
+    conversion, Kline, KlineInterval, Market, MarketDataType, OrderBook, OrderBookEntry,
+    SubscriptionType, Ticker, Trade, WebSocketConfig,
 };
+use crate::exchanges::bybit::codec::BybitWsEvent;
 use crate::exchanges::bybit::conversions::{
     convert_bybit_kline, convert_bybit_market, kline_interval_to_bybit_string,
 };
@@ -71,14 +73,58 @@ impl<R: RestClient + 'static, W: Send + Sync + 'static> MarketDataSource for Mar
     /// Subscribe to market data via WebSocket
     async fn subscribe_market_data(
         &self,
-        _symbols: Vec<String>,
-        _subscription_types: Vec<SubscriptionType>,
+        symbols: Vec<String>,
+        subscription_types: Vec<SubscriptionType>,
         _config: Option<WebSocketConfig>,
     ) -> Result<mpsc::Receiver<MarketDataType>, ExchangeError> {
-        // WebSocket implementation not yet ready
-        Err(ExchangeError::Other(
-            "WebSocket market data subscription not implemented yet".to_string(),
-        ))
+        let streams =
+            crate::exchanges::bybit::create_bybit_stream_identifiers(&symbols, &subscription_types);
+        let ws_url = self.get_websocket_url();
+        let codec = crate::exchanges::bybit::codec::BybitCodec;
+        let ws_session =
+            crate::core::kernel::ws::TungsteniteWs::new(ws_url, "bybit".to_string(), codec);
+
+        let mut reconnect_ws = crate::core::kernel::ws::ReconnectWs::new(ws_session)
+            .with_auto_resubscribe(true)
+            .with_max_reconnect_attempts(u32::MAX);
+
+        reconnect_ws.connect().await.map_err(|e| {
+            ExchangeError::Other(format!(
+                "Failed to connect to WebSocket for symbols: {:?}, error: {}",
+                symbols, e
+            ))
+        })?;
+
+        if !streams.is_empty() {
+            let stream_refs: Vec<&str> = streams.iter().map(String::as_str).collect();
+            reconnect_ws.subscribe(&stream_refs).await.map_err(|e| {
+                ExchangeError::Other(format!(
+                    "Failed to subscribe to streams: {:?}, error: {}",
+                    streams, e
+                ))
+            })?;
+        }
+
+        let (tx, rx) = mpsc::channel(1000);
+
+        tokio::spawn(async move {
+            while let Some(result) = reconnect_ws.next_message().await {
+                match result {
+                    Ok(bybit_event) => {
+                        if let Some(market_data) = convert_bybit_event_to_market_data(bybit_event) {
+                            if tx.send(market_data).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("WebSocket error: {:?}", e);
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
     }
 
     /// Get WebSocket endpoint URL for market data
@@ -162,5 +208,57 @@ impl<R: RestClient + 'static, W: Send + Sync + 'static> MarketDataSource for Mar
         }
 
         Ok(klines)
+    }
+}
+
+fn convert_bybit_event_to_market_data(event: BybitWsEvent) -> Option<MarketDataType> {
+    match event {
+        BybitWsEvent::Ticker { data } => Some(MarketDataType::Ticker(Ticker {
+            symbol: conversion::string_to_symbol(&data.symbol),
+            price: conversion::string_to_price(&data.price),
+            price_change: conversion::string_to_price("0"),
+            price_change_percent: conversion::string_to_decimal(&data.price_24h_pcnt),
+            high_price: conversion::string_to_price(&data.high_price_24h),
+            low_price: conversion::string_to_price(&data.low_price_24h),
+            volume: conversion::string_to_volume(&data.volume_24h),
+            quote_volume: conversion::string_to_volume(&data.turnover_24h),
+            open_time: data.timestamp.parse().unwrap_or(0),
+            close_time: data.timestamp.parse().unwrap_or(0),
+            count: 0,
+        })),
+        BybitWsEvent::OrderBook { data } => Some(MarketDataType::OrderBook(OrderBook {
+            symbol: conversion::string_to_symbol(&data.symbol),
+            bids: data
+                .bids
+                .into_iter()
+                .map(|[price, quantity]| OrderBookEntry {
+                    price: conversion::string_to_price(&price),
+                    quantity: conversion::string_to_quantity(&quantity),
+                })
+                .collect(),
+            asks: data
+                .asks
+                .into_iter()
+                .map(|[price, quantity]| OrderBookEntry {
+                    price: conversion::string_to_price(&price),
+                    quantity: conversion::string_to_quantity(&quantity),
+                })
+                .collect(),
+            last_update_id: data.update_id,
+        })),
+        BybitWsEvent::Trade { data } => Some(MarketDataType::Trade(Trade {
+            symbol: conversion::string_to_symbol(&data.symbol),
+            id: data.trade_id.parse().unwrap_or(0),
+            price: conversion::string_to_price(&data.price),
+            quantity: conversion::string_to_quantity(&data.size),
+            time: data.timestamp,
+            is_buyer_maker: data.side == "Sell",
+        })),
+        BybitWsEvent::Kline { data } => {
+            convert_bybit_kline(&data.kline, &data.symbol, data.kline.interval.as_str())
+                .ok()
+                .map(MarketDataType::Kline)
+        }
+        BybitWsEvent::Pong { .. } | BybitWsEvent::Unknown => None,
     }
 }

--- a/src/exchanges/bybit/mod.rs
+++ b/src/exchanges/bybit/mod.rs
@@ -39,8 +39,9 @@ pub fn create_bybit_stream_identifiers(
                 crate::core::types::SubscriptionType::Trades => {
                     streams.push(format!("publicTrade.{}", symbol));
                 }
-                crate::core::types::SubscriptionType::OrderBook { depth: _ } => {
-                    streams.push(format!("orderbook.{}.200ms", symbol));
+                crate::core::types::SubscriptionType::OrderBook { depth } => {
+                    let depth = depth.unwrap_or(1);
+                    streams.push(format!("orderbook.{}.{}", depth, symbol));
                 }
                 crate::core::types::SubscriptionType::Klines { interval } => {
                     let interval_str =
@@ -54,4 +55,45 @@ pub fn create_bybit_stream_identifiers(
     }
 
     streams
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::{KlineInterval, SubscriptionType};
+
+    #[test]
+    fn stream_identifiers_match_bybit_v5_topics() {
+        let symbols = vec!["BTCUSDT".to_string()];
+        let subscription_types = vec![
+            SubscriptionType::Ticker,
+            SubscriptionType::Trades,
+            SubscriptionType::OrderBook { depth: Some(50) },
+            SubscriptionType::Klines {
+                interval: KlineInterval::Minutes1,
+            },
+        ];
+
+        let streams = create_bybit_stream_identifiers(&symbols, &subscription_types);
+
+        assert_eq!(
+            streams,
+            vec![
+                "tickers.BTCUSDT",
+                "publicTrade.BTCUSDT",
+                "orderbook.50.BTCUSDT",
+                "kline.1.BTCUSDT"
+            ]
+        );
+    }
+
+    #[test]
+    fn orderbook_without_depth_uses_level_one_topic() {
+        let symbols = vec!["BTCUSDT".to_string()];
+        let subscription_types = vec![SubscriptionType::OrderBook { depth: None }];
+
+        let streams = create_bybit_stream_identifiers(&symbols, &subscription_types);
+
+        assert_eq!(streams, vec!["orderbook.1.BTCUSDT"]);
+    }
 }

--- a/src/exchanges/bybit/types.rs
+++ b/src/exchanges/bybit/types.rs
@@ -288,33 +288,53 @@ pub struct BybitOrderResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BybitWebSocketTicker {
     pub symbol: String,
+    #[serde(rename = "lastPrice", alias = "price")]
     pub price: String,
+    #[serde(rename = "price24hPcnt", alias = "price_24h_pcnt", default)]
     pub price_24h_pcnt: String,
+    #[serde(rename = "price1hPcnt", alias = "price_1h_pcnt", default)]
     pub price_1h_pcnt: String,
+    #[serde(rename = "highPrice24h", alias = "high_price_24h", default)]
     pub high_price_24h: String,
+    #[serde(rename = "lowPrice24h", alias = "low_price_24h", default)]
     pub low_price_24h: String,
+    #[serde(rename = "turnover24h", alias = "turnover_24h", default)]
     pub turnover_24h: String,
+    #[serde(rename = "volume24h", alias = "volume_24h", default)]
     pub volume_24h: String,
+    #[serde(rename = "usdIndexPrice", alias = "usd_index_price", default)]
     pub usd_index_price: String,
+    #[serde(default)]
     pub timestamp: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BybitWebSocketOrderBook {
+    #[serde(rename = "s", alias = "symbol")]
     pub symbol: String,
+    #[serde(rename = "b", alias = "bids", default)]
     pub bids: Vec<[String; 2]>,
+    #[serde(rename = "a", alias = "asks", default)]
     pub asks: Vec<[String; 2]>,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(rename = "u", alias = "update_id", default)]
     pub update_id: i64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BybitWebSocketTrade {
+    #[serde(rename = "s", alias = "symbol")]
     pub symbol: String,
+    #[serde(rename = "p", alias = "price")]
     pub price: String,
+    #[serde(rename = "v", alias = "size")]
     pub size: String,
+    #[serde(rename = "S", alias = "side")]
     pub side: String,
-    pub timestamp: String,
+    #[serde(rename = "T", alias = "timestamp", default)]
+    pub timestamp: i64,
+    #[serde(rename = "i", alias = "trade_id")]
     pub trade_id: String,
 }
 
@@ -326,14 +346,22 @@ pub struct BybitWebSocketKline {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BybitKlineData {
+    #[serde(rename = "start", alias = "start_time")]
     pub start_time: i64,
+    #[serde(rename = "end", alias = "end_time")]
     pub end_time: i64,
     pub interval: String,
+    #[serde(rename = "open", alias = "open_price")]
     pub open_price: String,
+    #[serde(rename = "high", alias = "high_price")]
     pub high_price: String,
+    #[serde(rename = "low", alias = "low_price")]
     pub low_price: String,
+    #[serde(rename = "close", alias = "close_price")]
     pub close_price: String,
+    #[serde(default)]
     pub volume: String,
+    #[serde(default)]
     pub turnover: String,
 }
 


### PR DESCRIPTION
## Summary
- implement Bybit spot `subscribe_market_data` using the shared Tungstenite/Reconnect WebSocket path
- generate valid Bybit V5 spot stream topics for ticker, trades, order book, and klines
- decode real Bybit spot WebSocket payloads into connector events and forward them as unified market data

## Root Cause
Bybit spot exposed WebSocket URLs and codec scaffolding, but `subscribe_market_data` still returned a placeholder "not implemented" error. The existing stream helper also emitted the wrong order book topic shape.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo audit`
- `cargo doc --no-deps --document-private-items --all-features`
- `cargo run`

Closes #18