### PR TITLE
[codex] Complete root connector exports

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,7 +103,7 @@ Risks and debt:
 
 - WebSocket support exists in the kernel and several modules, but default builders are not uniformly WebSocket-enabled. Call the explicit WebSocket builder when a module exposes one.
 - `ExchangeConnector` is not the best documentation surface today; prefer the smaller capability traits when writing examples or new code.
-- `src/lib.rs` re-exports only part of the exchange surface. The reliable public namespace is still `lotusx::exchanges::<exchange>`.
+- `src/lib.rs` re-exports connector types for all active exchanges. Use `lotusx::exchanges::<exchange>` for builders and exchange-specific API details.
 - Some legacy compatibility constructors keep old names or parameters while delegating to the new builders. Prefer the direct `build_connector*` functions in new code.
 - `ExchangeFactory` is for latency tests and demos. It now delegates Bybit and OKX creation through the exchange builders, but production code should still prefer exchange-specific builders when credentials, passphrases, or custom behavior matter.
 - `RestClientConfig::max_retries` applies to retryable GET and DELETE failures. POST requests are not automatically retried to avoid repeating order-style side effects.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,11 @@ pub mod exchanges;
 pub mod utils;
 
 pub use core::{errors::ExchangeError, traits::ExchangeConnector, types::*};
+pub use exchanges::backpack::BackpackConnector;
 pub use exchanges::binance::BinanceConnector;
+pub use exchanges::binance_perp::BinancePerpConnector;
 pub use exchanges::bybit::BybitConnector;
 pub use exchanges::bybit_perp::BybitPerpConnector;
+pub use exchanges::hyperliquid::HyperliquidConnector;
+pub use exchanges::okx::OkxConnector;
+pub use exchanges::paradex::ParadexConnector;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,0 +1,15 @@
+use lotusx::core::kernel::ReqwestRest;
+
+fn assert_connector_type<T>() {}
+
+#[test]
+fn root_reexports_active_connector_types() {
+    assert_connector_type::<lotusx::BackpackConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::BinanceConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::BinancePerpConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::BybitConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::BybitPerpConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::HyperliquidConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::OkxConnector<ReqwestRest>>();
+    assert_connector_type::<lotusx::ParadexConnector<ReqwestRest>>();
+}


### PR DESCRIPTION
## Summary
- Re-export connector types for every active exchange from the crate root.
- Add a public API compile test that verifies the root connector surface stays complete.
- Update `docs/ARCHITECTURE.md` to describe root exports as connector-type only, with exchange modules remaining the home for builders and exchange-specific details.

## Root Cause
`src/lib.rs` exposed only a subset of active connector types. That made the crate root look like an incomplete public API surface while the active exchange list lives under `lotusx::exchanges`.

## Validation
- `cargo test --test public_api --all-features` fails before the export change and passes after it
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo doc --no-deps --document-private-items --all-features`
- `cargo audit` exits 0 with existing allowed warnings for `dotenv`, `rustls-pemfile`, `keccak`, and `rand`
- `cargo run`